### PR TITLE
go.mod: Require at least go1.19

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module barney.ci/go-store
 
-go 1.18
+go 1.19
 
 require golang.org/x/sys v0.5.0


### PR DESCRIPTION
Before go1.19 the unix build tag wasn't well supported. Trying to consume this module in linux with go1.18 or earlier results in build errors because no implementation of `lock` can be found.